### PR TITLE
Add Respoke-SDK header to requests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,16 @@
 apply plugin: "java"
 
+def getVersionName = { ->
+    def stdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'describe', '--tags'
+        standardOutput = stdout
+    }
+    return stdout.toString().trim().replaceAll("^v", "")
+}
+
+version = getVersionName()
+
 repositories {
     mavenCentral()
 }
@@ -21,6 +32,11 @@ sourceSets {
 
 jar {
     from configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
+
+    manifest {
+        attributes("Implementation-Title": "Respoke-Java")
+        attributes("Implementation-Version": version)
+    }
 }
 
 test {

--- a/maven.gradle
+++ b/maven.gradle
@@ -9,7 +9,6 @@ signing {
 
 group = "com.digium.respoke"
 archivesBaseName = "respoke-java"
-version = "1.0.0"
 
 uploadArchives {
     repositories {

--- a/src/com/digium/respoke/Respoke.java
+++ b/src/com/digium/respoke/Respoke.java
@@ -11,7 +11,7 @@ package com.digium.respoke;
 
 import java.net.URI;
 import java.util.HashMap;
-
+import java.lang.Package;
 import lombok.Getter;
 import lombok.Setter;
 import org.json.JSONObject;
@@ -41,6 +41,17 @@ public class Respoke {
 
     @Setter
     private String tokenId;
+
+    private String getSDKHeader() {
+        Package pkg = getClass().getPackage();
+        String javaVersion = String.format("Java/%s", System.getProperty("java.version"));
+        String osVersion = String.format("%s %s",
+                System.getProperty("os.name"), System.getProperty("os.version"));
+        String packageVersion = String.format("%s/%s", pkg.getImplementationTitle(),
+                pkg.getImplementationVersion());
+
+        return String.format("%s (%s) %s", packageVersion, osVersion, javaVersion);
+    }
 
     /**
      * Respoke Constructor
@@ -125,6 +136,7 @@ public class Respoke {
             HttpResponse<JsonNode> tokenRespoke = Unirest.post(uri)
                 .header("Content-type", "application/json")
                 .header("App-Secret", appSecret)
+                .header("Respoke-SDK", this.getSDKHeader())
                 .body(new JSONObject()
                         .put("appId", appId)
                         .put("endpointId", endpointId)


### PR DESCRIPTION
This patch adds a "Respoke-SDK" header to the request, which includes
the version of the Respoke-Java library, the operating system the
request is coming from, and the version of Java the request is coming
from. 

The library version is pulled from the package manifest, which is
located in the .jar file at `META-INF/MANIFEST.MF`. This file is
populated by the gradle build, and the version is determined by the
command `git describe --tags` with the 'v' that prepends the tag
stripped off. This means that to get a "clean" version, i.e. one
without the number of commits past the tag and the hash appended
to it, you have to perform the build directly after having tagged
a release in git.

Unfortunately, the manifest information is not available when the
tests are run, so under test the first portion of the Respoke-SDK
header that is sent will render as "null/null". I was unable to
find a workaround for this. It only is an issue at test time... I
was able to test it by pulling the built artifact into a separate
project and performing a request using the library and was able
to verify that the header rendered correctly.

<img width="669" alt="screen shot 2015-09-24 at 9 45 19 pm" src="https://cloud.githubusercontent.com/assets/309219/10092347/f8dc18a4-630a-11e5-99c5-8b05295d3eed.png">

This patch is related to MER-4340.
